### PR TITLE
Document minimum python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Python 3 check local import for flake8
 pip install flake8-local-import
 ```
 
+**Note**: This plugin requires Python 3.8 or above.
+
 # Configuration
 
 You will want to set the `app-import-names` option to a comma separated

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setuptools.setup(
         "flake8_local_import",
     ],
     install_requires=requires,
+    python_requires='>=3.8',
     entry_points={
         flake8_entry_point: [
             'LI = flake8_local_import:LocalImportPlugin',


### PR DESCRIPTION
Hi,

I was trying to use this plugin for a Python 3.7 project and ran into an issue because of the use of `functools.cached_property` (which is new in 3.8).

Here is a PR that adds a small note in the install section of the README, plus a setting in `setup.py` to prevent installing the plugin on incompatible python versions (see https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires).

A better fix might be to remove the dependency on `cached_property` but that might require more effort whereas this seems like a quick and easy fix.

Thanks ✨ 